### PR TITLE
refactor: remove unused Page import

### DIFF
--- a/app/services/playwright_service.py
+++ b/app/services/playwright_service.py
@@ -1,4 +1,4 @@
-from playwright.async_api import async_playwright, Browser, Page
+from playwright.async_api import async_playwright, Browser
 from typing import Optional, Dict, Any
 import logging
 from app.config import settings


### PR DESCRIPTION
## Summary
- remove unused Page import in Playwright service

## Testing
- `pytest`
- `ruff check app/services/playwright_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68b60af6a5d0832aa5e6539aed2696fa